### PR TITLE
Master

### DIFF
--- a/HaoConnect/ios/HaoConnect/HaoConnect.m
+++ b/HaoConnect/ios/HaoConnect/HaoConnect.m
@@ -44,9 +44,9 @@ static NSString * Checkcode   = @""; //Userid和Logintime组合加密后的产�
     Logintime = loginTime;
     Checkcode = checkCode;
 
-    [[NSUserDefaults standardUserDefaults] setObject:userid forKey:@"userid"];
-    [[NSUserDefaults standardUserDefaults] setObject:loginTime forKey:@"loginTime"];
-    [[NSUserDefaults standardUserDefaults] setObject:checkCode forKey:@"checkCode"];
+    [[NSUserDefaults standardUserDefaults] setObject:NSValueToString(userid) forKey:@"userid"];
+    [[NSUserDefaults standardUserDefaults] setObject:NSValueToString(loginTime) forKey:@"loginTime"];
+    [[NSUserDefaults standardUserDefaults] setObject:NSValueToString(checkCode) forKey:@"checkCode"];
 
 
 }


### PR DESCRIPTION
1、userid、loginTime、checkCode的数据类型可能为__NSCFNumber，这可能会大导致HaoConnect内部核心框架
判断出错，如果类型为__NSCFString则没有问题。
