### PR TITLE
优化userid、loginTime、checkCode存储数据类型

### DIFF
--- a/HaoConnect/ios/HaoConnect/HaoConnect.m
+++ b/HaoConnect/ios/HaoConnect/HaoConnect.m
@@ -40,13 +40,13 @@ static NSString * Checkcode   = @""; //Userid和Logintime组合加密后的产�
 
 + (void)setCurrentUserInfo:(NSString *)userid :(NSString *)loginTime :(NSString *)checkCode{
     
-    Userid = userid;
-    Logintime = loginTime;
-    Checkcode = checkCode;
-
-    [[NSUserDefaults standardUserDefaults] setObject:NSValueToString(userid) forKey:@"userid"];
-    [[NSUserDefaults standardUserDefaults] setObject:NSValueToString(loginTime) forKey:@"loginTime"];
-    [[NSUserDefaults standardUserDefaults] setObject:NSValueToString(checkCode) forKey:@"checkCode"];
+    Userid    = [NSString stringWithFormat:@"%@", userid];
+    Logintime = [NSString stringWithFormat:@"%@", loginTime];
+    Checkcode = [NSString stringWithFormat:@"%@", checkCode];
+    
+    [[NSUserDefaults standardUserDefaults] setObject:userid forKey:@"userid"];
+    [[NSUserDefaults standardUserDefaults] setObject:loginTime forKey:@"loginTime"];
+    [[NSUserDefaults standardUserDefaults] setObject:checkCode forKey:@"checkCode"];
 
 
 }


### PR DESCRIPTION
1、userid、loginTime、checkCode的数据类型可能为__NSCFNumber，这可能会大导致HaoConnect内部核心框架判断出错，如果类型为__NSCFString则没有问题。
